### PR TITLE
More tests for error paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ go get github.com/zhulik/pips
 
 ## Features
 
-- Type-safe pipelines using Go generics
+- "Type-safety": pipelines using Go generics for stages, butp pips uses `any` to move you the from one stage to another,
+  so it's your responsibility to use the correct types. In case of a type casting error, an error will be sent 
+  to the pipeline.
 - Concurrent processing with goroutines
 - Error handling throughout the pipeline
 - Composable stages for common operations:

--- a/apply/map.go
+++ b/apply/map.go
@@ -2,7 +2,6 @@ package apply
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/zhulik/pips"
@@ -21,12 +20,10 @@ func Map[I any, O any](mapper mapper[I, O]) pips.Stage {
 				var x I
 				res, err = mapper(ctx, convertSlice[I](anys, reflect.TypeOf(x).Elem()))
 			} else {
-				i, ok := item.(I)
-				if ok {
+				var i I
+				i, err = pips.TryCast[I](item)
+				if err == nil {
 					res, err = mapper(ctx, i)
-				} else {
-					var x I
-					err = fmt.Errorf("%w: expected: %T, given: %T", pips.ErrWrongType, x, item)
 				}
 			}
 			if err != nil {

--- a/apply/map.go
+++ b/apply/map.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/zhulik/pips"
@@ -20,7 +21,13 @@ func Map[I any, O any](mapper mapper[I, O]) pips.Stage {
 				var x I
 				res, err = mapper(ctx, convertSlice[I](anys, reflect.TypeOf(x).Elem()))
 			} else {
-				res, err = mapper(ctx, item.(I))
+				i, ok := item.(I)
+				if ok {
+					res, err = mapper(ctx, i)
+				} else {
+					var x I
+					err = fmt.Errorf("%w: expected: %T, given: %T", pips.ErrWrongType, x, item)
+				}
 			}
 			if err != nil {
 				return err

--- a/apply/mapc_test.go
+++ b/apply/mapc_test.go
@@ -50,4 +50,14 @@ func TestMapC(t *testing.T) {
 
 		testhelpers.RequireErroredPiping(t, out, errTest)
 	})
+
+	t.Run("panic", func(t *testing.T) {
+		t.Parallel()
+
+		out := testhelpers.TestStage(t, apply.MapC(2, func(_ context.Context, _ string) (string, error) {
+			panic(errTest)
+		}))
+
+		testhelpers.RequireErroredPiping(t, out, errTest)
+	})
 }

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,9 @@
+package pips_test
+
+import (
+	"errors"
+)
+
+var (
+	errTest = errors.New("test error")
+)

--- a/d.go
+++ b/d.go
@@ -1,7 +1,5 @@
 package pips
 
-import "fmt"
-
 // D is a pair of value and error, represents a piece of data in the pipeline.
 type D[T any] interface {
 	Unpack() (T, error)
@@ -36,10 +34,9 @@ func CastD[I any, O any](d D[I]) D[O] {
 		var t O
 		return NewD(t)
 	}
-	o, ok := v.(O)
-	if !ok {
-		var t O
-		return ErrD[O](fmt.Errorf("%w: expected: %T, given: %T", ErrWrongType, t, v))
+	o, err := TryCast[O](v)
+	if err != nil {
+		return ErrD[O](err)
 	}
 	return NewD(o)
 }

--- a/d.go
+++ b/d.go
@@ -1,5 +1,7 @@
 package pips
 
+import "fmt"
+
 // D is a pair of value and error, represents a piece of data in the pipeline.
 type D[T any] interface {
 	Unpack() (T, error)
@@ -34,7 +36,12 @@ func CastD[I any, O any](d D[I]) D[O] {
 		var t O
 		return NewD(t)
 	}
-	return NewD(v.(O))
+	o, ok := v.(O)
+	if !ok {
+		var t O
+		return ErrD[O](fmt.Errorf("%w: expected: %T, given: %T", ErrWrongType, t, v))
+	}
+	return NewD(o)
 }
 
 type pd[T any] struct {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+package pips
+
+import "errors"
+
+var (
+	ErrPanicInStage = errors.New("panic in stage")
+	ErrWrongType    = errors.New("wrong stage input or output type")
+)

--- a/pipeline.go
+++ b/pipeline.go
@@ -2,6 +2,7 @@ package pips
 
 import (
 	"context"
+	"fmt"
 )
 
 // Stage is a unit of work in the pipeline.
@@ -33,7 +34,7 @@ func (p *Pipeline[I, O]) Run(ctx context.Context, input <-chan D[I]) OutChan[O] 
 	for _, stage := range p.stages {
 		newOut := make(chan D[any])
 
-		go runStage(ctx, stage, inChan, newOut)
+		go p.runStage(ctx, stage, inChan, newOut)
 
 		inChan = newOut
 	}
@@ -41,25 +42,22 @@ func (p *Pipeline[I, O]) Run(ctx context.Context, input <-chan D[I]) OutChan[O] 
 	return CastDChan[any, O](ctx, inChan)
 }
 
-// ToStage turns the pipeline into a stage to be used in another pipeline.
-func (p *Pipeline[I, O]) ToStage() Stage {
-	return func(ctx context.Context, in <-chan D[any], out chan<- D[any]) {
-		for _, stage := range p.stages {
-			newOut := make(chan D[any])
+func (p *Pipeline[I, O]) runStage(ctx context.Context, stage Stage, in <-chan D[any], out chan<- D[any]) {
+	defer close(out)
 
-			go runStage(ctx, stage, in, newOut)
+	defer func() {
+		if r := recover(); r != nil {
+			var err error
 
-			in = newOut
+			if e, ok := r.(error); ok {
+				err = fmt.Errorf("%w: %w", ErrPanicInStage, e)
+			} else {
+				err = fmt.Errorf("%w: %+v", ErrPanicInStage, r)
+			}
+
+			out <- ErrD[any](err)
 		}
+	}()
 
-		MapToDChan(ctx, in, out, func(_ context.Context, item any, out chan<- D[any]) error {
-			out <- NewD(item)
-			return nil
-		})
-	}
-}
-
-func runStage(ctx context.Context, stage Stage, in <-chan D[any], out chan<- D[any]) {
 	stage(ctx, in, out)
-	close(out)
 }

--- a/pips.go
+++ b/pips.go
@@ -1,1 +1,13 @@
 package pips
+
+import "fmt"
+
+// TryCast tries to cast the value to the given type, return ErrWrongType if fails.
+func TryCast[O any](i any) (O, error) {
+	o, ok := i.(O)
+	if ok {
+		return o, nil
+	}
+
+	return o, fmt.Errorf("%w: expected: %T, given: %T", ErrWrongType, o, i)
+}

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -8,14 +8,14 @@ import (
 	"github.com/zhulik/pips"
 )
 
-func InputChan() <-chan pips.D[any] {
-	ch := make(chan pips.D[any])
+func InputChan() <-chan pips.D[string] {
+	ch := make(chan pips.D[string])
 
 	go func() {
-		ch <- pips.AnyD("test")
-		ch <- pips.AnyD("foo")
-		ch <- pips.AnyD("bazz")
-		ch <- pips.AnyD("train")
+		ch <- pips.NewD("test")
+		ch <- pips.NewD("foo")
+		ch <- pips.NewD("bazz")
+		ch <- pips.NewD("train")
 		close(ch)
 	}()
 
@@ -59,6 +59,8 @@ func RequireSuccessfulPiping[T any](t *testing.T, out pips.OutChan[T], expected 
 }
 
 func RequireErroredPiping[T any](t *testing.T, out pips.OutChan[T], expected error) {
+	t.Helper()
+
 	_, err := out.Collect(t.Context())
 
 	require.ErrorIs(t, err, expected)


### PR DESCRIPTION
Changes:
- Avoid panicking on type casting, send errors to the pipeline instead.
- Delete `Pipeline.ToStage` as `apply.Pipeline` exists.
- Add more  tests for error paths