### PR TITLE
Turn stage into interface

### DIFF
--- a/apply/batch.go
+++ b/apply/batch.go
@@ -7,17 +7,80 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// BatchConfig represents configuration for Batch and Rebatch stages
 type BatchConfig struct {
 	FlushInterval time.Duration
 }
 
+// WithFlushInterval sets the flush interval for Batch and Rebatch stages using the provided duration.
 func WithFlushInterval(interval time.Duration) BatchConfigurer {
 	return func(config *BatchConfig) {
 		config.FlushInterval = interval
 	}
 }
 
+// BatchConfigurer defines a function type used to configure a BatchConfig instance.
 type BatchConfigurer func(*BatchConfig)
+
+// BatchStage represents a pipeline stage that buffers data into batches based on size or flush interval.
+type BatchStage struct {
+	batchSize int
+	config    *BatchConfig
+}
+
+// Run runs the stage.
+func (b BatchStage) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
+	buffer := make([]any, 0, b.batchSize)
+
+	var flushTicker *time.Ticker
+	var tickChan <-chan time.Time
+
+	if b.config.FlushInterval > 0 {
+		flushTicker = time.NewTicker(b.config.FlushInterval)
+		defer flushTicker.Stop()
+		tickChan = flushTicker.C
+	} else {
+		tickChan = make(chan time.Time)
+	}
+
+	sendReset := func() {
+		if len(buffer) > 0 {
+			output <- pips.AnyD(buffer)
+			buffer = make([]any, 0, b.batchSize)
+			if flushTicker != nil {
+				flushTicker.Reset(b.config.FlushInterval)
+			}
+		}
+	}
+
+	defer sendReset()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-tickChan:
+			sendReset()
+			continue
+
+		case res, ok := <-input:
+			if !ok {
+				return
+			}
+			if res.Error() != nil {
+				output <- pips.ErrD[any](res.Error())
+				return
+			}
+
+			buffer = append(buffer, res.Value())
+
+			if len(buffer) >= b.batchSize {
+				sendReset()
+			}
+		}
+	}
+}
 
 // Batch creates a batching stage.
 func Batch(batchSize int, configurers ...BatchConfigurer) pips.Stage {
@@ -26,56 +89,8 @@ func Batch(batchSize int, configurers ...BatchConfigurer) pips.Stage {
 		c(config)
 	}
 
-	return func(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
-		buffer := make([]any, 0, batchSize)
-
-		var flushTicker *time.Ticker
-		var tickChan <-chan time.Time
-
-		if config.FlushInterval > 0 {
-			flushTicker = time.NewTicker(config.FlushInterval)
-			defer flushTicker.Stop()
-			tickChan = flushTicker.C
-		} else {
-			tickChan = make(chan time.Time)
-		}
-
-		sendReset := func() {
-			if len(buffer) > 0 {
-				output <- pips.AnyD(buffer)
-				buffer = make([]any, 0, batchSize)
-				if flushTicker != nil {
-					flushTicker.Reset(config.FlushInterval)
-				}
-			}
-		}
-
-		defer sendReset()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-
-			case <-tickChan:
-				sendReset()
-				continue
-
-			case res, ok := <-input:
-				if !ok {
-					return
-				}
-				if res.Error() != nil {
-					output <- pips.ErrD[any](res.Error())
-					return
-				}
-
-				buffer = append(buffer, res.Value())
-
-				if len(buffer) >= batchSize {
-					sendReset()
-				}
-			}
-		}
+	return BatchStage{
+		batchSize: batchSize,
+		config:    config,
 	}
 }

--- a/apply/batch.go
+++ b/apply/batch.go
@@ -7,12 +7,17 @@ import (
 	"github.com/zhulik/pips"
 )
 
-// BatchConfig represents configuration for Batch and Rebatch stages
+// BatchConfig represents configuration for Batch and Rebatch stages.
+// It contains settings that control the behavior of batching operations.
 type BatchConfig struct {
+	// FlushInterval defines the maximum time to wait before flushing a batch,
+	// even if the batch size hasn't been reached.
 	FlushInterval time.Duration
 }
 
 // WithFlushInterval sets the flush interval for Batch and Rebatch stages using the provided duration.
+// This configurer allows batches to be emitted after a specified time period,
+// even if they haven't reached the maximum batch size.
 func WithFlushInterval(interval time.Duration) BatchConfigurer {
 	return func(config *BatchConfig) {
 		config.FlushInterval = interval
@@ -20,15 +25,20 @@ func WithFlushInterval(interval time.Duration) BatchConfigurer {
 }
 
 // BatchConfigurer defines a function type used to configure a BatchConfig instance.
+// It's used to provide a functional options pattern for configuring batch stages.
 type BatchConfigurer func(*BatchConfig)
 
 // BatchStage represents a pipeline stage that buffers data into batches based on size or flush interval.
+// It collects individual items into batches and emits them when either the batch size is reached
+// or the flush interval has elapsed.
 type BatchStage struct {
 	batchSize int
 	config    *BatchConfig
 }
 
 // Run runs the stage.
+// It processes input data by collecting items into batches and sending them to the output channel
+// when either the batch size is reached or the flush interval has elapsed.
 func (b BatchStage) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
 	buffer := make([]any, 0, b.batchSize)
 
@@ -83,6 +93,9 @@ func (b BatchStage) Run(ctx context.Context, input <-chan pips.D[any], output ch
 }
 
 // Batch creates a batching stage.
+// It collects individual items into batches of the specified size and emits them as a single item.
+// The batchSize parameter determines the maximum number of items in each batch.
+// Optional configurers can be provided to customize the batching behavior, such as setting a flush interval.
 func Batch(batchSize int, configurers ...BatchConfigurer) pips.Stage {
 	config := &BatchConfig{}
 	for _, c := range configurers {

--- a/apply/each.go
+++ b/apply/each.go
@@ -6,9 +6,15 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// eacher is a function type that processes an item of type T and returns an error if the processing fails.
+// It's used by the Each stage to perform operations on each item in the pipeline without changing the item itself.
 type eacher[T any] func(context.Context, T) error
 
 // Each creates an each stage.
+// An each stage applies the provided eacher function to each item in the pipeline,
+// but passes the original item unchanged to the next stage.
+// This is useful for side effects like logging, metrics collection, or other operations
+// where you want to process each item without transforming it.
 func Each[I any](eacher eacher[I]) pips.Stage {
 	return Map(func(ctx context.Context, item I) (I, error) {
 		return item, eacher(ctx, item)

--- a/apply/eachc.go
+++ b/apply/eachc.go
@@ -7,6 +7,12 @@ import (
 )
 
 // EachC creates a concurrent each stage.
+// A concurrent each stage applies the provided eacher function to each item in the pipeline
+// with a specified level of concurrency, but passes the original item unchanged to the next stage.
+// The concurrency parameter determines the maximum number of items that can be processed simultaneously.
+// This is useful for side effects like logging, metrics collection, or other operations
+// where you want to process each item without transforming it, but need to do so concurrently
+// for performance reasons, especially for operations that may block or take significant time.
 func EachC[I any](concurrency int, eacher eacher[I]) pips.Stage {
 	return MapC(concurrency, func(ctx context.Context, item I) (I, error) {
 		return item, eacher(ctx, item)

--- a/apply/filter.go
+++ b/apply/filter.go
@@ -9,24 +9,33 @@ import (
 
 type filter[T any] func(context.Context, T) (bool, error)
 
+type FilterStage[T any] struct {
+	filter filter[T]
+}
+
+// Run runs the stage.
+func (f FilterStage[T]) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
+	pips.MapToDChan(ctx, input, output, func(ctx context.Context, item any, out chan<- pips.D[any]) error {
+		i, err := pips.TryCast[T](item)
+		if err != nil {
+			return fmt.Errorf("failed to cast filter stage input: %w", err)
+		}
+
+		keep, err := f.filter(ctx, i)
+		if err != nil {
+			return err
+		}
+		if keep {
+			out <- pips.NewD(item)
+		}
+
+		return nil
+	})
+}
+
 // Filter creates a filter stage.
 func Filter[T any](filter filter[T]) pips.Stage {
-	return func(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
-		pips.MapToDChan(ctx, input, output, func(ctx context.Context, item any, out chan<- pips.D[any]) error {
-			i, err := pips.TryCast[T](item)
-			if err != nil {
-				return fmt.Errorf("failed to cast filter stage input: %w", err)
-			}
-
-			keep, err := filter(ctx, i)
-			if err != nil {
-				return err
-			}
-			if keep {
-				out <- pips.NewD(item)
-			}
-
-			return nil
-		})
+	return FilterStage[T]{
+		filter: filter,
 	}
 }

--- a/apply/filter.go
+++ b/apply/filter.go
@@ -7,13 +7,20 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// filter is a function type that evaluates an item of type T and returns a boolean indicating
+// whether the item should be kept in the pipeline, along with any error that occurred during evaluation.
+// It's used by the Filter stage to determine which items should continue through the pipeline.
 type filter[T any] func(context.Context, T) (bool, error)
 
+// FilterStage represents a pipeline stage that filters items based on a predicate function.
+// It passes only items that satisfy the filter condition to the next stage.
 type FilterStage[T any] struct {
 	filter filter[T]
 }
 
 // Run runs the stage.
+// It processes input data by applying the filter function to each item and only passing
+// items that satisfy the filter condition to the output channel.
 func (f FilterStage[T]) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
 	pips.MapToDChan(ctx, input, output, func(ctx context.Context, item any, out chan<- pips.D[any]) error {
 		i, err := pips.TryCast[T](item)
@@ -34,6 +41,10 @@ func (f FilterStage[T]) Run(ctx context.Context, input <-chan pips.D[any], outpu
 }
 
 // Filter creates a filter stage.
+// A filter stage evaluates each item in the pipeline using the provided filter function
+// and only passes items that satisfy the filter condition (return true) to the next stage.
+// Items that don't satisfy the condition are dropped from the pipeline.
+// This is useful for removing unwanted items from the data stream based on some criteria.
 func Filter[T any](filter filter[T]) pips.Stage {
 	return FilterStage[T]{
 		filter: filter,

--- a/apply/flatten.go
+++ b/apply/flatten.go
@@ -6,9 +6,13 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// FlattenStage represents a pipeline stage that flattens slices or arrays into individual items.
+// It takes slices or arrays as input and emits each element as a separate item in the pipeline.
 type FlattenStage struct{}
 
 // Run runs the stage.
+// It processes input data by taking slices or arrays and emitting each element
+// as a separate item in the output channel.
 func (f FlattenStage) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
 	pips.MapToDChan(ctx, input, output, func(_ context.Context, item any, out chan<- pips.D[any]) error {
 		iterateAnySlice(item, func(item any) {
@@ -19,6 +23,9 @@ func (f FlattenStage) Run(ctx context.Context, input <-chan pips.D[any], output 
 }
 
 // Flatten creates a flattening stage.
+// A flattening stage takes slices or arrays as input and emits each element as a separate item in the pipeline.
+// This is useful when you have a pipeline that produces collections of items, but you want to process
+// each item individually in subsequent stages.
 func Flatten() pips.Stage {
 	return FlattenStage{}
 }

--- a/apply/flatten.go
+++ b/apply/flatten.go
@@ -6,14 +6,19 @@ import (
 	"github.com/zhulik/pips"
 )
 
+type FlattenStage struct{}
+
+// Run runs the stage.
+func (f FlattenStage) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
+	pips.MapToDChan(ctx, input, output, func(_ context.Context, item any, out chan<- pips.D[any]) error {
+		iterateAnySlice(item, func(item any) {
+			out <- pips.AnyD(item)
+		})
+		return nil
+	})
+}
+
 // Flatten creates a flattening stage.
 func Flatten() pips.Stage {
-	return func(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
-		pips.MapToDChan(ctx, input, output, func(_ context.Context, item any, out chan<- pips.D[any]) error {
-			iterateAnySlice(item, func(item any) {
-				out <- pips.AnyD(item)
-			})
-			return nil
-		})
-	}
+	return FlattenStage{}
 }

--- a/apply/map.go
+++ b/apply/map.go
@@ -7,13 +7,20 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// mapper is a function type that transforms an item of type I into an item of type O,
+// potentially returning an error if the transformation fails.
+// It's used by the Map stage to transform items in the pipeline.
 type mapper[I any, O any] func(context.Context, I) (O, error)
 
+// MapperStage represents a pipeline stage that transforms items using a mapper function.
+// It takes items of type I as input and emits items of type O as output.
 type MapperStage[I any, O any] struct {
 	mapper mapper[I, O]
 }
 
 // Run runs the stage.
+// It processes input data by applying the mapper function to each item
+// and sending the transformed items to the output channel.
 func (m MapperStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
 	pips.MapToDChan(ctx, input, output, func(ctx context.Context, item any, out chan<- pips.D[any]) error {
 		out <- pips.AnyD(mapItemOrSlice(ctx, item, m.mapper))
@@ -23,6 +30,10 @@ func (m MapperStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], ou
 }
 
 // Map creates a map stage.
+// A map stage transforms each item in the pipeline using the provided mapper function.
+// It takes items of type I as input and emits items of type O as output.
+// This is the most common way to transform data in a pipeline, allowing you to convert
+// from one data type to another or modify the content of items.
 func Map[I any, O any](mapper mapper[I, O]) pips.Stage {
 	return MapperStage[I, O]{
 		mapper: mapper,
@@ -47,6 +58,9 @@ func convertSlice[T any](sourceSlice []any, targetElementType reflect.Type) T {
 	return targetSlice.Interface().(T)
 }
 
+// iterateAnySlice iterates over a slice of any type and calls the provided function for each element.
+// It uses reflection to handle slices of any type.
+// Panics if the provided item is not a slice.
 func iterateAnySlice(item any, fn func(any)) {
 	if reflect.TypeOf(item).Kind() == reflect.Slice {
 		s := reflect.ValueOf(item)
@@ -59,6 +73,9 @@ func iterateAnySlice(item any, fn func(any)) {
 	panic("not a slice")
 }
 
+// mapItemOrSlice applies the mapper function to an item or to each element of a slice.
+// If the item is a slice, it converts the slice to the expected input type before applying the mapper.
+// If the item is not a slice, it attempts to cast it to the expected input type before applying the mapper.
 func mapItemOrSlice[I any, O any](ctx context.Context, item any, mapper mapper[I, O]) (O, error) {
 	var i I
 

--- a/apply/mapc.go
+++ b/apply/mapc.go
@@ -6,46 +6,57 @@ import (
 	"github.com/zhulik/pips"
 )
 
-// MapC creates a concurrent map stage.
-func MapC[I any, O any](concurrency int, mapper mapper[I, O]) pips.Stage {
-	return func(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
-		semaphore := make(chan any, concurrency)
-		midChan := make(chan pips.D[chan pips.D[any]], concurrency)
+type MapCStage[I any, O any] struct {
+	concurrency int
+	mapper      mapper[I, O]
+}
 
-		go func() {
-			defer close(semaphore)
-			defer close(midChan)
+// Run runs the stage.
+func (m MapCStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
+	semaphore := make(chan any, m.concurrency)
+	midChan := make(chan pips.D[chan pips.D[any]], m.concurrency)
 
-			pips.MapToDChan(ctx, input, midChan, func(ctx context.Context, item any, out chan<- pips.D[chan pips.D[any]]) error {
-				semaphore <- true
+	go func() {
+		defer close(semaphore)
+		defer close(midChan)
 
-				ch := make(chan pips.D[any])
+		pips.MapToDChan(ctx, input, midChan, func(ctx context.Context, item any, out chan<- pips.D[chan pips.D[any]]) error {
+			semaphore <- true
 
-				go func() {
-					defer func() { <-semaphore }()
-					defer close(ch)
-					defer pips.RecoverPanicAndSendToPipeline(ch)
+			ch := make(chan pips.D[any])
 
-					ch <- pips.AnyD(mapItemOrSlice(ctx, item, mapper))
-				}()
+			go func() {
+				defer func() { <-semaphore }()
+				defer close(ch)
+				defer pips.RecoverPanicAndSendToPipeline(ch)
 
-				out <- pips.NewD(ch)
+				ch <- pips.AnyD(mapItemOrSlice(ctx, item, m.mapper))
+			}()
 
-				return nil
-			})
-		}()
-		pips.MapToDChan(ctx, midChan, output, func(ctx context.Context, c chan pips.D[any], out chan<- pips.D[any]) error {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			out <- pips.NewD(ch)
 
-			case d, ok := <-c:
-				if !ok {
-					return nil
-				}
-				out <- d
+			return nil
+		})
+	}()
+	pips.MapToDChan(ctx, midChan, output, func(ctx context.Context, c chan pips.D[any], out chan<- pips.D[any]) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case d, ok := <-c:
+			if !ok {
 				return nil
 			}
-		})
+			out <- d
+			return nil
+		}
+	})
+}
+
+// MapC creates a concurrent map stage.
+func MapC[I any, O any](concurrency int, mapper mapper[I, O]) pips.Stage {
+	return MapCStage[I, O]{
+		mapper:      mapper,
+		concurrency: concurrency,
 	}
 }

--- a/apply/mapc.go
+++ b/apply/mapc.go
@@ -6,12 +6,18 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// MapCStage represents a pipeline stage that transforms items using a mapper function with concurrency.
+// It takes items of type I as input and emits items of type O as output,
+// processing multiple items simultaneously up to the specified concurrency limit.
 type MapCStage[I any, O any] struct {
 	concurrency int
 	mapper      mapper[I, O]
 }
 
 // Run runs the stage.
+// It processes input data by applying the mapper function to each item concurrently,
+// up to the specified concurrency limit, and sending the transformed items to the output channel.
+// This implementation uses a semaphore pattern to limit concurrency and goroutines to process items in parallel.
 func (m MapCStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
 	semaphore := make(chan any, m.concurrency)
 	midChan := make(chan pips.D[chan pips.D[any]], m.concurrency)
@@ -54,6 +60,11 @@ func (m MapCStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], outp
 }
 
 // MapC creates a concurrent map stage.
+// A concurrent map stage transforms each item in the pipeline using the provided mapper function,
+// processing multiple items simultaneously up to the specified concurrency limit.
+// The concurrency parameter determines the maximum number of items that can be processed in parallel.
+// This is useful for performance-intensive transformations or operations that may block,
+// such as network requests or file I/O, allowing the pipeline to continue processing other items.
 func MapC[I any, O any](concurrency int, mapper mapper[I, O]) pips.Stage {
 	return MapCStage[I, O]{
 		mapper:      mapper,

--- a/apply/pipeline.go
+++ b/apply/pipeline.go
@@ -6,17 +6,26 @@ import (
 	"github.com/zhulik/pips"
 )
 
+type PipelineStage[I any, O any] struct {
+	pipeline *pips.Pipeline[I, O]
+}
+
+// Run runs the stage.
+func (p PipelineStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
+	pips.MapToDChan(
+		ctx,
+		p.pipeline.Run(ctx, pips.CastDChan[any, I](ctx, input)),
+		output,
+		func(_ context.Context, item O, out chan<- pips.D[any]) error {
+			out <- pips.AnyD(item)
+			return nil
+		},
+	)
+}
+
 // Pipeline creates a pipeline stage.
 func Pipeline[I any, O any](pipeline *pips.Pipeline[I, O]) pips.Stage {
-	return func(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
-		pips.MapToDChan(
-			ctx,
-			pipeline.Run(ctx, pips.CastDChan[any, I](ctx, input)),
-			output,
-			func(_ context.Context, item O, out chan<- pips.D[any]) error {
-				out <- pips.AnyD(item)
-				return nil
-			},
-		)
+	return PipelineStage[I, O]{
+		pipeline: pipeline,
 	}
 }

--- a/apply/pipeline.go
+++ b/apply/pipeline.go
@@ -6,11 +6,17 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// PipelineStage represents a pipeline stage that embeds another pipeline.
+// It allows for composition of pipelines, where one pipeline can be used as a stage within another pipeline.
+// It takes items of type I as input and emits items of type O as output, using the embedded pipeline for processing.
 type PipelineStage[I any, O any] struct {
 	pipeline *pips.Pipeline[I, O]
 }
 
 // Run runs the stage.
+// It processes input data by passing it to the embedded pipeline and then forwarding
+// the results from that pipeline to the output channel of the current stage.
+// This enables pipeline composition, where complex data processing can be broken down into smaller, reusable pipelines.
 func (p PipelineStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
 	pips.MapToDChan(
 		ctx,
@@ -24,6 +30,11 @@ func (p PipelineStage[I, O]) Run(ctx context.Context, input <-chan pips.D[any], 
 }
 
 // Pipeline creates a pipeline stage.
+// A pipeline stage embeds another pipeline within the current pipeline, allowing for pipeline composition.
+// It takes a pipeline that processes items of type I and produces items of type O,
+// and returns a stage that can be used in another pipeline.
+// This enables complex data processing to be broken down into smaller, reusable pipelines
+// that can be composed together to form more complex processing flows.
 func Pipeline[I any, O any](pipeline *pips.Pipeline[I, O]) pips.Stage {
 	return PipelineStage[I, O]{
 		pipeline: pipeline,

--- a/apply/rebatch.go
+++ b/apply/rebatch.go
@@ -7,12 +7,18 @@ import (
 	"github.com/zhulik/pips"
 )
 
+// RebatchStage represents a pipeline stage that rebatches data from existing batches into new batches.
+// It takes batches (slices) as input, flattens them, and then creates new batches of the specified size.
+// This is useful when you need to change the batch size in the middle of a pipeline.
 type RebatchStage struct {
 	batchSize int
 	config    *BatchConfig
 }
 
 // Run runs the stage.
+// It processes input data by taking batches (slices), flattening them into individual items,
+// and then collecting those items into new batches of the specified size.
+// Like BatchStage, it also supports flushing batches based on a time interval.
 func (r RebatchStage) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
 	buffer := make([]any, 0, r.batchSize)
 
@@ -69,6 +75,12 @@ func (r RebatchStage) Run(ctx context.Context, input <-chan pips.D[any], output 
 }
 
 // Rebatch creates a rebatching stage.
+// A rebatching stage takes batches (slices) as input, flattens them into individual items,
+// and then collects those items into new batches of the specified size.
+// The batchSize parameter determines the maximum number of items in each new batch.
+// Optional configurers can be provided to customize the rebatching behavior, such as setting a flush interval.
+// This is useful when you need to change the batch size in the middle of a pipeline,
+// or when you need to process batches from an upstream source but with a different batch size.
 func Rebatch(batchSize int, configurers ...BatchConfigurer) pips.Stage {
 	config := &BatchConfig{}
 	for _, c := range configurers {

--- a/apply/rebatch.go
+++ b/apply/rebatch.go
@@ -7,6 +7,67 @@ import (
 	"github.com/zhulik/pips"
 )
 
+type RebatchStage struct {
+	batchSize int
+	config    *BatchConfig
+}
+
+// Run runs the stage.
+func (r RebatchStage) Run(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
+	buffer := make([]any, 0, r.batchSize)
+
+	var flushTicker *time.Ticker
+	var tickChan <-chan time.Time
+
+	if r.config.FlushInterval > 0 {
+		flushTicker = time.NewTicker(r.config.FlushInterval)
+		defer flushTicker.Stop()
+		tickChan = flushTicker.C
+	} else {
+		tickChan = make(chan time.Time)
+	}
+
+	sendReset := func() {
+		if len(buffer) > 0 {
+			output <- pips.AnyD(buffer)
+			buffer = make([]any, 0, r.batchSize)
+			if flushTicker != nil {
+				flushTicker.Reset(r.config.FlushInterval)
+			}
+		}
+	}
+
+	defer sendReset()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-tickChan:
+			sendReset()
+			continue
+
+		case res, ok := <-input:
+			if !ok {
+				return
+			}
+			if res.Error() != nil {
+				output <- pips.ErrD[any](res.Error())
+				return
+			}
+
+			iterateAnySlice(res.Value(), func(item any) {
+				buffer = append(buffer, item)
+
+				if len(buffer) >= r.batchSize {
+					sendReset()
+				}
+			})
+		}
+	}
+}
+
 // Rebatch creates a rebatching stage.
 func Rebatch(batchSize int, configurers ...BatchConfigurer) pips.Stage {
 	config := &BatchConfig{}
@@ -14,58 +75,8 @@ func Rebatch(batchSize int, configurers ...BatchConfigurer) pips.Stage {
 		c(config)
 	}
 
-	return func(ctx context.Context, input <-chan pips.D[any], output chan<- pips.D[any]) {
-		buffer := make([]any, 0, batchSize)
-
-		var flushTicker *time.Ticker
-		var tickChan <-chan time.Time
-
-		if config.FlushInterval > 0 {
-			flushTicker = time.NewTicker(config.FlushInterval)
-			defer flushTicker.Stop()
-			tickChan = flushTicker.C
-		} else {
-			tickChan = make(chan time.Time)
-		}
-
-		sendReset := func() {
-			if len(buffer) > 0 {
-				output <- pips.AnyD(buffer)
-				buffer = make([]any, 0, batchSize)
-				if flushTicker != nil {
-					flushTicker.Reset(config.FlushInterval)
-				}
-			}
-		}
-
-		defer sendReset()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-
-			case <-tickChan:
-				sendReset()
-				continue
-
-			case res, ok := <-input:
-				if !ok {
-					return
-				}
-				if res.Error() != nil {
-					output <- pips.ErrD[any](res.Error())
-					return
-				}
-
-				iterateAnySlice(res.Value(), func(item any) {
-					buffer = append(buffer, item)
-
-					if len(buffer) >= batchSize {
-						sendReset()
-					}
-				})
-			}
-		}
+	return RebatchStage{
+		batchSize: batchSize,
+		config:    config,
 	}
 }

--- a/apply/zip.go
+++ b/apply/zip.go
@@ -7,6 +7,11 @@ import (
 )
 
 // Zip creates a zip stage.
+// A zip stage transforms each item in the pipeline using the provided zipper function,
+// but instead of replacing the original item, it pairs the original item with the transformed item.
+// It takes items of type I as input and emits pairs (pips.P) of the original item and the transformed item.
+// This is useful when you need to keep the original item along with its transformed version
+// for later processing or reference.
 func Zip[I any, O any](zipper mapper[I, O]) pips.Stage {
 	return Map(func(ctx context.Context, i I) (pips.P[I, O], error) {
 		o, err := zipper(ctx, i)

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,7 +11,9 @@ import (
 // Stage should consume from the input channel and produce to the
 // output channel. The stage must not close channels, must block.
 // When using background routines: they must exit when the context is canceled or the input channel is closed.
-type Stage func(context.Context, <-chan D[any], chan<- D[any])
+type Stage interface {
+	Run(context.Context, <-chan D[any], chan<- D[any])
+}
 
 // Pipeline is a sequence of stages.
 type Pipeline[I any, O any] struct {
@@ -48,7 +50,7 @@ func (p *Pipeline[I, O]) runStage(ctx context.Context, stage Stage, in <-chan D[
 	defer close(out)
 	defer RecoverPanicAndSendToPipeline(out)
 
-	stage(ctx, in, out)
+	stage.Run(ctx, in, out)
 }
 
 func RecoverPanicAndSendToPipeline[T any](out chan<- D[T]) {

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -48,7 +48,7 @@ func TestStageWith(t *testing.T, stage pips.Stage, items []any) <-chan pips.D[an
 
 	out := make(chan pips.D[any])
 	go func() {
-		stage(t.Context(), ch, out)
+		stage.Run(t.Context(), ch, out)
 		close(out)
 	}()
 


### PR DESCRIPTION
This lets us store additional meta-information in the stage instance such as the source code location the stage was created at.